### PR TITLE
Updated Params for osfamily

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,6 +1,6 @@
 class motd::params {
-  case $::operatingsystem {
-    ubuntu, debian: {
+  case $::osfamily {
+    redhat, debian: {
       $config_file = '/etc/motd'
       $template = 'motd/motd.erb'
     }


### PR DESCRIPTION
Enables support for redhat/centos/fedora systems, so far from testing it appears to work fine on centos6 systems, I assume it should work on others as well.
