### PR TITLE
Added new parameter for direct inline_template content

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name    'saz-motd'
-version '2.0.3'
+version '2.1.0'
 source 'UNKNOWN'
 author 'saz'
 license 'Apache License, Version 2.0'

--- a/README.md
+++ b/README.md
@@ -12,3 +12,4 @@ Manage 'Message Of The Day' via Puppet
 * ensure: present or absent, default: present.
 * config_file: string, default: OS specific. Set config_file, if platform is not supported.
 * template: string, default: OS specific. Set template, if platform is not supported.
+* inline_template: string, default: not set. String with the actual template, overrides *template* param.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,9 +13,14 @@
 #     Default: auto-set, platform specific
 #
 #   [*template*]
-#     Template to use.
+#     Template file to use.
 #     Only set this, if your platform is not supported or you know, what you're doing.
 #     Default: auto-set, platform specific
+#
+#   [*inline_template*]
+#     String with the template itself.
+#     It has preference over the *template* parameter, if defined.
+#     Default: not set.
 #
 # Actions:
 #   Manages 'Message Of The Day' content.


### PR DESCRIPTION
Surprisingly enough, nobody developed this feature before...

BTW, your tags start with v, and puppetlabs standards are without it.
