### PR TITLE
Fix template variable deprecation warnings for Puppet > 3.2

### DIFF
--- a/templates/motd.erb
+++ b/templates/motd.erb
@@ -1,10 +1,10 @@
 
-<%= operatingsystem %> <%= operatingsystemrelease %> <%= architecture %>
+<%= scope.lookupvar('::operatingsystem') %> <%= scope.lookupvar('::operatingsystemrelease') %> <%= scope.lookupvar('::architecture') %>
 
-FQDN:      <%= fqdn %> (<%= ipaddress %>)
-<% if has_variable?("processor0") then -%>
-Processor: <%= processorcount %>x <%= processor0 %>
+FQDN:      <%= scope.lookupvar('::fqdn') %> (<%= scope.lookupvar('::ipaddress') %>)
+<% if scope.lookupvar('::processor0') then -%>
+Processor: <%= scope.lookupvar('::processorcount') %>x <%= scope.lookupvar('::processor0') %>
 <% end -%>
-Kernel:    <%= kernelrelease %>
-Memory:    <%= memorysize %>
+Kernel:    <%= scope.lookupvar('::kernelrelease') %>
+Memory:    <%= scope.lookupvar('::memorysize') %>
 


### PR DESCRIPTION
The current template causes deprecation warnings with current Puppet versions. This change fixes the warnings.
