### PR TITLE
Use motd.tail for Debian and Ubuntu

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,7 +1,11 @@
 class motd::params {
   case $::osfamily {
-    redhat, debian, suse, gentoo: {
+    redhat, suse, gentoo: {
       $config_file = '/etc/motd'
+      $template = 'motd/motd.erb'
+    }
+    debian: {
+      $config_file = '/etc/motd.motd'
       $template = 'motd/motd.erb'
     }
     default: {


### PR DESCRIPTION
On Ubuntu and Debain the motd.tail should be used rather than the motd file. Otherwise this will be overwritten on boot by the scripts in /etc/update-motd.d/

p.s. Sorry, I haven't used pull request before, so might have made a duplicate bug report..
