### PR TITLE
Fixed the parameters being passed into motd class

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -35,7 +35,8 @@
 class motd(
   $ensure = 'present',
   $config_file = $motd::params::config_file,
-  $template = $motd::params::template
+  $template = $motd::params::template,
+  $inline_template = undef
 ) inherits motd::params {
 
   if $ensure == 'present' {


### PR DESCRIPTION
Added the parameter '$inline_template'. Looks like it was missed out.
