### PR TITLE
undef does not equal '' with future parser

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -36,7 +36,7 @@ class motd(
   $ensure = 'present',
   $config_file = $motd::params::config_file,
   $template = $motd::params::template,
-  $inline_template = undef
+  $inline_template = ''
 ) inherits motd::params {
 
   if $ensure == 'present' {


### PR DESCRIPTION
With future parser an undef string does not == an empty string. Since the case statement also does not include the special word `undef` set $inline_template = '' to work correctly with the case statement.

see: https://tickets.puppetlabs.com/browse/PUP-1807
