### PR TITLE
Added support for AIX

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -54,9 +54,9 @@ class motd(
 
   file { $config_file:
     ensure  => $ensure_real,
-    owner   => 'root',
-    group   => 'root',
-    mode    => '0644',
+    owner   => $motd::params::owner,
+    group   => $motd::params::group,
+    mode    => $motd::params::mode,
     content => $file_content,
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,12 +1,20 @@
 class motd::params {
   case $::osfamily {
-    redhat, debian, suse, gentoo, AIX: {
+    'AIX': {
+      $config_file = '/etc/motd'
+      $template = 'motd/motd.erb'
+    }
+      redhat, debian, suse, gentoo : {
       $config_file = '/etc/motd'
       $template = 'motd/motd.erb'
     }
     default: {
       case $::operatingsystem {
-        gentoo, AIX: {
+        'AIX': {
+          $config_file = '/etc/motd'
+          $template = 'motd/motd.erb'
+        }
+        gentoo: {
           $config_file = '/etc/motd'
           $template = 'motd/motd.erb'
         }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,6 +1,6 @@
 class motd::params {
   case $::osfamily {
-    redhat, debian, suse, gentoo: {
+    redhat, debian, suse, gentoo,AIX: {
       $config_file = '/etc/motd'
       $template = 'motd/motd.erb'
     }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,20 +3,32 @@ class motd::params {
     'AIX': {
       $config_file = '/etc/motd'
       $template = 'motd/motd.erb'
+      $mode = '0644'
+      $owner = 'root'
+      $group = 'bin'
     }
       redhat, debian, suse, gentoo : {
       $config_file = '/etc/motd'
       $template = 'motd/motd.erb'
+      $mode = '0644'
+      $owner = 'root'
+      $group = 'root'
     }
     default: {
       case $::operatingsystem {
         'AIX': {
           $config_file = '/etc/motd'
           $template = 'motd/motd.erb'
+          $mode = '0644'
+          $owner = 'root'
+          $group = 'bin'
         }
         gentoo: {
           $config_file = '/etc/motd'
           $template = 'motd/motd.erb'
+          $mode = '0644'
+          $owner = 'root'
+          $group = 'root'
         }
         default: {
           fail("The ${module_name} module is not supported on ${::osfamily}/${::operatingsystem}.")

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,7 +6,7 @@ class motd::params {
     }
     default: {
       case $::operatingsystem {
-        gentoo: {
+        gentoo, AIX: {
           $config_file = '/etc/motd'
           $template = 'motd/motd.erb'
         }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,6 +1,6 @@
 class motd::params {
   case $::osfamily {
-    redhat, debian, suse, gentoo,AIX: {
+    redhat, debian, suse, gentoo, AIX: {
       $config_file = '/etc/motd'
       $template = 'motd/motd.erb'
     }

--- a/templates/motd.erb
+++ b/templates/motd.erb
@@ -1,3 +1,4 @@
 
 FQDN    :    <%= scope.lookupvar('::fqdn') %> (<%= scope.lookupvar('::ipaddress') %>)
 OSlevel :    <%= scope.lookupvar('::kernelrelease') %>
+

--- a/templates/motd.erb
+++ b/templates/motd.erb
@@ -1,10 +1,3 @@
 
-<%= scope.lookupvar('::operatingsystem') %> <%= scope.lookupvar('::operatingsystemrelease') %> <%= scope.lookupvar('::architecture') %>
-
-FQDN:      <%= scope.lookupvar('::fqdn') %> (<%= scope.lookupvar('::ipaddress') %>)
-<% if scope.lookupvar('::processor0') then -%>
-Processor: <%= scope.lookupvar('::processorcount') %>x <%= scope.lookupvar('::processor0') %>
-<% end -%>
-Kernel:    <%= scope.lookupvar('::kernelrelease') %>
-Memory:    <%= scope.lookupvar('::memorysize') %>
-
+FQDN    :    <%= scope.lookupvar('::fqdn') %> (<%= scope.lookupvar('::ipaddress') %>)
+OSlevel :    <%= scope.lookupvar('::kernelrelease') %>


### PR DESCRIPTION
Hi,

I changed the params.pp to allow support of the motd file for AIX, AIX doesn't use root:root for owner group instead it is root:bin so I made the changes needed as well as I split out mode also incase people have a more secure mode for AIX some use 0444 instead of 0644.
The init.pp file is also modified to point to params for owner group and mode
